### PR TITLE
playerbots_as_seller_and_buyer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ local.properties
 #
 # Visual Studio Code
 #
+.vscode
 [.vscode](http://_vscodecontentref_/11)
 /.vscode/
 .vscode-test/*

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -113,8 +113,17 @@ AuctionHouseBot.UseBuyPriceForSeller = 0
 AuctionHouseBot.UseBuyPriceForBuyer = 0
 AuctionHouseBot.UseMarketPriceForSeller = 0
 AuctionHouseBot.MarketResetThreshold = 25
+
+# define a fixed account and characters which will be used as AHBots
 AuctionHouseBot.Account = 0
 AuctionHouseBot.GUIDs = 0
+
+# Enable the use of playerbots GUIDs as sellers and buyers instead of using the fixed account
+AuctionHouseBot.UsePlayerbotsAsAHBots = 0
+
+# Prefix for playerbots account names (used to identify playerbots)
+AuctionHouseBot.PlayerbotsAccountPrefix = "RNDBOT"
+
 AuctionHouseBot.ItemsPerCycle = 200
 AuctionHouseBot.ConsiderOnlyBotAuctions = 0
 AuctionHouseBot.DuplicatesCount = 0


### PR DESCRIPTION
## Changes Proposed:
- Added support for using playerbots as auction house bots by querying their GUIDs from the database based on account name prefix.
- Improved bot GUID management by replacing vector with a global set for uniqueness and efficient lookups.
- Simplified bot GUID loading logic by removing redundant calls and using a centralized GUID set.
- Enhanced error handling and logging for invalid GUIDs and missing configurations.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5 
<!-- GitButler Footer Boundary Bottom -->

